### PR TITLE
hotfix-OA-190

### DIFF
--- a/source/otus-participant/src/main/java/org/ccem/otus/participant/model/Participant.java
+++ b/source/otus-participant/src/main/java/org/ccem/otus/participant/model/Participant.java
@@ -2,6 +2,7 @@ package org.ccem.otus.participant.model;
 
 import br.org.tutty.Equalization;
 import com.google.gson.GsonBuilder;
+import org.bson.types.BSONTimestamp;
 import org.bson.types.ObjectId;
 import org.ccem.otus.model.FieldCenter;
 import org.ccem.otus.participant.utils.LongAdapter;
@@ -55,9 +56,9 @@ public class Participant {
     return this.email;
   }
 
-  public void setName(String name) {
-    this.name = name;
-  }
+  public void setEmail(String email) { this.email = email.toLowerCase();}
+
+  public void setName(String name) { this.name = name; }
 
   public FieldCenter getFieldCenter() {
     return fieldCenter;
@@ -123,11 +124,13 @@ public class Participant {
   }
 
   public static String serialize(Participant participantJson) {
+    participantJson.setEmail(participantJson.getEmail());
     return Participant.getGsonBuilder().create().toJson(participantJson);
   }
 
   public static Participant deserialize(String participantJson) {
     Participant participant = Participant.getGsonBuilder().create().fromJson(participantJson, Participant.class);
+    participant.setEmail(participant.getEmail());
     return participant;
   }
 

--- a/source/otus-participant/src/main/java/org/ccem/otus/participant/model/Participant.java
+++ b/source/otus-participant/src/main/java/org/ccem/otus/participant/model/Participant.java
@@ -124,14 +124,18 @@ public class Participant {
   }
 
   public static String serialize(Participant participantJson) {
-    participantJson.setEmail(participantJson.getEmail());
+    emailToLowerCase(participantJson);
     return Participant.getGsonBuilder().create().toJson(participantJson);
   }
 
   public static Participant deserialize(String participantJson) {
     Participant participant = Participant.getGsonBuilder().create().fromJson(participantJson, Participant.class);
-    participant.setEmail(participant.getEmail());
+    emailToLowerCase(participant);
     return participant;
+  }
+
+  private static void emailToLowerCase(Participant participant){
+    if(participant.email != null) participant.setEmail(participant.getEmail());
   }
 
   public static GsonBuilder getGsonBuilder() {

--- a/source/otus-participant/src/main/java/org/ccem/otus/participant/model/Participant.java
+++ b/source/otus-participant/src/main/java/org/ccem/otus/participant/model/Participant.java
@@ -2,7 +2,6 @@ package org.ccem.otus.participant.model;
 
 import br.org.tutty.Equalization;
 import com.google.gson.GsonBuilder;
-import org.bson.types.BSONTimestamp;
 import org.bson.types.ObjectId;
 import org.ccem.otus.model.FieldCenter;
 import org.ccem.otus.participant.utils.LongAdapter;

--- a/source/otus-participant/src/test/java/org/ccem/otus/model/ParticipantTest.java
+++ b/source/otus-participant/src/test/java/org/ccem/otus/model/ParticipantTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 public class ParticipantTest {
-
   Participant participant = new Participant(5001007l);
   Participant participantRecruitmentNumberNull = new Participant(null);
   Participant participantThat = new Participant(1063154l);
@@ -66,5 +65,4 @@ public class ParticipantTest {
     String participantJson = "{\"email\": \"ABC@GMAIL.COM\"}";
     assertEquals(Participant.deserialize(participantJson).getEmail(), "abc@gmail.com");
   }
-
 }

--- a/source/otus-participant/src/test/java/org/ccem/otus/model/ParticipantTest.java
+++ b/source/otus-participant/src/test/java/org/ccem/otus/model/ParticipantTest.java
@@ -53,7 +53,18 @@ public class ParticipantTest {
   @Test
   public void method_hashCode_sould_not_codify_recruitmentNumber_is_null() {
     assertEquals(0, participantRecruitmentNumberNull.hashCode());
+  }
 
+  @Test
+  public void should_check_if_there_is_lowerCaseTreatment_for_emailAttribute_by_serializeMethod(){
+    Participant participantWithEmail = Participant.deserialize("{\"email\": \"ABC@GMAIL.COM\"}");
+    assertEquals(Participant.serialize(participantWithEmail), "{\"email\":\"abc@gmail.com\"}");
+  }
+
+  @Test
+  public void should_check_if_there_is_lowerCaseTreatment_for_emailAttribute_by_deserializeMethod(){
+    String participantJson = "{\"email\": \"ABC@GMAIL.COM\"}";
+    assertEquals(Participant.deserialize(participantJson).getEmail(), "abc@gmail.com");
   }
 
 }

--- a/source/otus-persistence/src/test/java/br/org/mongodb/codecs/UserCodecTest.java
+++ b/source/otus-persistence/src/test/java/br/org/mongodb/codecs/UserCodecTest.java
@@ -1,8 +1,5 @@
 package br.org.mongodb.codecs;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-
 import br.org.otus.model.User;
 import org.bson.BsonInvalidOperationException;
 import org.bson.BsonReader;
@@ -16,14 +13,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import java.util.ArrayList;
 import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ObjectId.class, User.class})

--- a/source/otus-persistence/src/test/java/br/org/mongodb/codecs/UserCodecTest.java
+++ b/source/otus-persistence/src/test/java/br/org/mongodb/codecs/UserCodecTest.java
@@ -16,9 +16,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 import java.util.ArrayList;
 import java.util.UUID;
@@ -39,7 +41,6 @@ public class UserCodecTest {
   private static final String FIELDCENTERACRONYM = "FC";
   private static final String IPFORTEST = "192.168.0.1";
   private User userSpy = spy(new User());
-
 
   @InjectMocks
   private UserCodec UserCodec;
@@ -94,6 +95,7 @@ public class UserCodecTest {
 
   @Test
   public void method_decode_should_evocate_functions_that_started_and_finished_BsonReaderDocument() throws Exception {
+    PowerMockito.when(reader.readString("email")).thenReturn(EMAIL);
     DecoderContext decoderContext = DecoderContext.builder().build();
     PowerMockito.when(reader.readString("uuid")).thenReturn(UUIDString);
     PowerMockito.when(reader.readBsonType()).thenReturn(BsonType.END_OF_DOCUMENT);

--- a/source/otus-user/src/main/java/br/org/otus/model/User.java
+++ b/source/otus-user/src/main/java/br/org/otus/model/User.java
@@ -114,6 +114,8 @@ public class User {
     return email;
   }
 
+  public void setEmail(String email) { this.email = email.toLowerCase();}
+
   public String getPassword() {
     return password;
   }
@@ -154,11 +156,6 @@ public class User {
     this.code = code;
   }
 
-  public static User deserialize(String user) {
-    GsonBuilder builder = new GsonBuilder();
-    return builder.create().fromJson(user, User.class);
-  }
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -179,10 +176,6 @@ public class User {
     this.phone = phone;
   }
 
-  public void setEmail(String email) {
-    this.email = email;
-  }
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -191,15 +184,27 @@ public class User {
     this.extractionToken = ExtractionToken;
   }
 
-  public static String serialize(User user) {
-    return new GsonBuilder().create().toJson(user);
-  }
-
   public void set_id(ObjectId id) {
     this._id = id;
   }
 
   public ObjectId get_id() {
     return _id;
+  }
+
+  public static User deserialize(String userJson) {
+    GsonBuilder builder = new GsonBuilder();
+    User user = builder.create().fromJson(userJson, User.class);
+    emailToLowerCase(user);
+    return user;
+  }
+
+  public static String serialize(User user) {
+    emailToLowerCase(user);
+    return new GsonBuilder().create().toJson(user);
+  }
+
+  private static void emailToLowerCase(User user){
+    if(user.email != null) user.setEmail(user.getEmail());
   }
 }

--- a/source/otus-user/src/test/java/br/org/otus/model/UserTest.java
+++ b/source/otus-user/src/test/java/br/org/otus/model/UserTest.java
@@ -1,0 +1,11 @@
+package br.org.otus.model;
+
+import org.junit.Before;
+
+import static org.junit.Assert.*;
+public class UserTest {
+
+    @Before
+    public void setUp() throws Exception {
+    }
+}

--- a/source/otus-user/src/test/java/br/org/otus/model/UserTest.java
+++ b/source/otus-user/src/test/java/br/org/otus/model/UserTest.java
@@ -1,11 +1,24 @@
 package br.org.otus.model;
 
 import org.junit.Before;
+import org.junit.Test;
 
 import static org.junit.Assert.*;
+
 public class UserTest {
 
-    @Before
-    public void setUp() throws Exception {
-    }
+  @Before
+  public void setUp() throws Exception {}
+
+  @Test
+  public void should_check_if_there_is_lowerCaseTreatment_for_emailAttribute_by_serializeMethod(){
+    User userWithEmail = User.deserialize("{\"email\": \"ABC@GMAIL.COM\"}");
+    assertTrue(User.serialize(userWithEmail).contains("\"email\":\"abc@gmail.com\""));
+  }
+
+  @Test
+  public void should_check_if_there_is_lowerCaseTreatment_for_emailAttribute_by_deserializeMethod(){
+    String userJson = "{\"email\": \"ABC@GMAIL.COM\"}";
+    assertEquals(User.deserialize(userJson).getEmail(), "abc@gmail.com");
+  }
 }


### PR DESCRIPTION
Tratamento na API: Aos valores de email (em participant e user). Deverão ficar com o texto com caixa baixa (lower case) , e continuar contruindo as instancias quando não tiverem email. 