### PR TITLE
OA-200 refinamento para sinalizar o outcomes ausente ou rota invalida

### DIFF
--- a/source/otus-business/src/main/java/br/org/otus/outcomes/FollowUpFacade.java
+++ b/source/otus-business/src/main/java/br/org/otus/outcomes/FollowUpFacade.java
@@ -20,6 +20,7 @@ import org.ccem.otus.participant.model.Participant;
 
 import javax.inject.Inject;
 import javax.ws.rs.core.Response;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.logging.Logger;
@@ -228,7 +229,7 @@ public class FollowUpFacade {
       throw new HttpResponseException(Validation.build(e.getCause().getMessage()));
     } catch (RequestException ex) {
       throw new HttpResponseException(new ResponseInfo(Response.Status.fromStatusCode(ex.getErrorCode()), ex.getErrorMessage(), ex.getErrorContent()));
-    } catch (JsonSyntaxException e) {
+    } catch (JsonSyntaxException | IOException e) {
       callOtuscomesErrorLog(activityId, status, ACCOMPLISHED_METHOD, e);
       return false;
     }
@@ -241,14 +242,15 @@ public class FollowUpFacade {
       throw new HttpResponseException(Validation.build(e.getCause().getMessage()));
     } catch (RequestException ex) {
       throw new HttpResponseException(new ResponseInfo(Response.Status.fromStatusCode(ex.getErrorCode()), ex.getErrorMessage(), ex.getErrorContent()));
-    } catch (JsonSyntaxException e) {
+    } catch (JsonSyntaxException | IOException e) {
       callOtuscomesErrorLog(activityId, status, REOPEN_METHOD, e);
       return false;
     }
   }
-  private void callOtuscomesErrorLog(String activityId, String status, String action, JsonSyntaxException e){
-    LOGGER.severe(""  + "info: " + Response.Status.fromStatusCode(502)+ ", cause: OUTCOMES COMMUNICATION FAIL"
-    +"\nactivityId: " + activityId +", status:" + status + ", action:"+action);
+
+  private void callOtuscomesErrorLog(String activityId, String status, String action, Exception e) {
+    LOGGER.severe("" + "info: " + Response.Status.fromStatusCode(502) + ", cause: OUTCOMES COMMUNICATION FAIL"
+      + "\nactivityId: " + activityId + ", status:" + status + ", action:" + action);
   }
 
   public Object listAllParticipantEvents(String rn) {

--- a/source/otus-gateway/src/main/java/br/org/otus/gateway/gates/OutcomeGatewayService.java
+++ b/source/otus-gateway/src/main/java/br/org/otus/gateway/gates/OutcomeGatewayService.java
@@ -125,26 +125,18 @@ public class OutcomeGatewayService {
     }
   }
 
-  public GatewayResponse accomplishedParticipantEventByActivity(String activityId) throws MalformedURLException {
+  public GatewayResponse accomplishedParticipantEventByActivity(String activityId) throws IOException {
     URL requestURL = new OutcomesMicroServiceResources().getAccomplishedParticipantEventAddressByActivity(activityId);
-    try {
-      JsonPUTRequestUtility jsonPUT = new JsonPUTRequestUtility(requestURL);
-      String response = jsonPUT.finish();
-      return new GatewayResponse().buildSuccess(response);
-    } catch (IOException ex) {
-      throw new ReadRequestException();
-    }
+    JsonPUTRequestUtility jsonPUT = new JsonPUTRequestUtility(requestURL);
+    String response = jsonPUT.finish();
+    return new GatewayResponse().buildSuccess(response);
   }
 
-  public GatewayResponse reopenedParticipantEventByActivity(String activityId) throws MalformedURLException {
+  public GatewayResponse reopenedParticipantEventByActivity(String activityId) throws IOException {
     URL requestURL = new OutcomesMicroServiceResources().getReopenedParticipantEventAddressByActivity(activityId);
-    try {
-      JsonPUTRequestUtility jsonPUT = new JsonPUTRequestUtility(requestURL);
-      String response = jsonPUT.finish();
-      return new GatewayResponse().buildSuccess(response);
-    } catch (IOException ex) {
-      throw new ReadRequestException();
-    }
+    JsonPUTRequestUtility jsonPUT = new JsonPUTRequestUtility(requestURL);
+    String response = jsonPUT.finish();
+    return new GatewayResponse().buildSuccess(response);
   }
 
   public GatewayResponse removeFollowUpEvent(String eventId) throws MalformedURLException {

--- a/source/otus-gateway/src/test/java/br/org/otus/gateway/gates/OutcomeGatewayServiceTest.java
+++ b/source/otus-gateway/src/test/java/br/org/otus/gateway/gates/OutcomeGatewayServiceTest.java
@@ -80,15 +80,6 @@ public class OutcomeGatewayServiceTest {
     assertTrue(service.accomplishedParticipantEventByActivity(ACTIVITY_ID) instanceof GatewayResponse);
   }
 
-  @Test(expected = ReadRequestException.class)
-  public void accomplishedParticipantEventByActivityMethod_should_catch_IOException() throws Exception {
-    whenNew(OutcomesMicroServiceResources.class).withAnyArguments().thenReturn(outcomesMicroServiceResources);
-    when(outcomesMicroServiceResources.getAccomplishedParticipantEventAddressByActivity(ACTIVITY_ID)).thenReturn(mockUrl);
-    whenNew(JsonPUTRequestUtility.class).withAnyArguments().thenReturn(jsonPUTRequestUtility);
-    Mockito.when(jsonPUTRequestUtility.finish()).thenThrow(new IOException(new Throwable()));
-    service.accomplishedParticipantEventByActivity(ACTIVITY_ID);
-  }
-
   @Test
   public void reopenedParticipantEventByActivityMethod_should_simulate_microserviceResponse() throws Exception {
     whenNew(OutcomesMicroServiceResources.class).withAnyArguments().thenReturn(outcomesMicroServiceResources);
@@ -96,14 +87,4 @@ public class OutcomeGatewayServiceTest {
     whenNew(JsonPUTRequestUtility.class).withAnyArguments().thenReturn(jsonPUTRequestUtility);
     assertTrue(service.reopenedParticipantEventByActivity(ACTIVITY_ID) instanceof GatewayResponse);
   }
-
-  @Test(expected = ReadRequestException.class)
-  public void reopenedParticipantEventByActivityMethod_should_catch_IOException() throws Exception {
-    whenNew(OutcomesMicroServiceResources.class).withAnyArguments().thenReturn(outcomesMicroServiceResources);
-    when(outcomesMicroServiceResources.getReopenedParticipantEventAddressByActivity(ACTIVITY_ID)).thenReturn(mockUrl);
-    whenNew(JsonPUTRequestUtility.class).withAnyArguments().thenReturn(jsonPUTRequestUtility);
-    Mockito.when(jsonPUTRequestUtility.finish()).thenThrow(new IOException(new Throwable()));
-    service.reopenedParticipantEventByActivity(ACTIVITY_ID);
-  }
-
 }


### PR DESCRIPTION
Em teste no otus, num cenário onde o container do outcomes não estaria levantado, a mensagem de erro original era trocada por uma mensagem que gerava duvidas. Nesta abordagem informamos que o microservice tem um problema de comunicação.
em caso de estar fora do ar ou de não ter alcançado a url